### PR TITLE
Actualizada regla no-unused-vars.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = {
     'no-param-reassign': ['off'],
     'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
     'no-restricted-globals': ['off'],
+    'no-unused-vars': ['error', {argsIgnorePattern: '_'}],
     'object-curly-newline': ['error', {multiline: true, consistent: true}],
     'object-curly-spacing': ['error', 'never'],
     'object-shorthand': ['error', 'always', {ignoreConstructors: false, avoidQuotes: false}],


### PR DESCRIPTION
Añadida excepción para poder definir parámetros de un método que no se usan usando la sintaxis: `_name`.