### PR TITLE
New version with major upgrades

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,8 +4,9 @@
 root = true
 
 [*]
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-indent_style = spaces
+indent_style = space
 indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2020-09-21
+
+### Added
+* Added new vue rule: vue/component-definition-name-casing
+* Configuration splitted in two parts: `nosolosoftware` and `nosolosoftware/vue`
+
+### Modified
+* Dependencies have been upgraded
+
 ## [2.3.0] - 2020-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,9 +21,17 @@ In order to use this configuration in our project, we should puts the following 
 
 ```yaml
 ---
-extends: nosolosoftware
+extends:
+  - nosolosoftware
 ```
 
+In those cases where Vuejs is being used, we encourage you to add:
+```yaml
+extends:
+  - nosolosoftware
+  - nosolosoftware/vue
+
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ In those cases where Vuejs is being used, we encourage you to add:
 extends:
   - nosolosoftware
   - nosolosoftware/vue
-
 ```
 
 ## Contributing

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
     'plugin:vue/recommended'
   ],
   parserOptions: {
+    ecmaVersion: 2020,
     sourceType: 'module'
   },
   rules: {

--- a/index.js
+++ b/index.js
@@ -5,8 +5,7 @@ module.exports = {
     es6: true
   },
   extends: [
-    'airbnb-base',
-    'plugin:vue/recommended'
+    'airbnb-base'
   ],
   parserOptions: {
     ecmaVersion: 2020,
@@ -40,30 +39,6 @@ module.exports = {
     'arrow-parens': ['error', 'as-needed'],
     'max-len': ['error', {code: 100}],
     semi: ['error', 'never', {beforeStatementContinuationChars: 'always'}],
-    'vue/order-in-components': ['error', {
-      order: [
-        'el',
-        'name',
-        'parent',
-        'functional',
-        'template',
-        ['delimiters', 'comments'],
-        ['components', 'directives', 'filters'],
-        'extends',
-        'mixins',
-        'inheritAttrs',
-        'model',
-        ['props', 'propsData'],
-        'data',
-        'computed',
-        'watch',
-        'LIFECYCLE_HOOKS',
-        'methods',
-        'render',
-        'renderError'
-      ]
-    }],
-    'vue/require-default-prop': ['off'],
     'newline-per-chained-call': ['off'],
     'no-multiple-empty-lines': ['error', {max: 1}]
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "author": "Juan Antonio Galisteo <jgalisteo@nosolosoftware.es>",
   "license": "MIT",
-  "homepage": "https://github.com/nosolosoftware/eslint-config-nss",
+  "homepage": "https://github.com/nosolosoftware/eslint-config-nosolosoftware",
   "repository": {
     "type": "git",
     "url": "https://github.com/nosolosoftware/eslint-config-nosolosoftware.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-nosolosoftware",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "NosoloSoftware Javascript style guide",
   "main": "index.js",
   "author": "Juan Antonio Galisteo <jgalisteo@nosolosoftware.es>",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "nosolosoftware"
   ],
   "peerDependencies": {
-    "eslint": "^5.6.0",
-    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint": "^7.9.0",
+    "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-vue": "^5.0.0-beta.3"
+    "eslint-plugin-vue": "^7.0.0-beta.3"
   }
 }

--- a/vue.js
+++ b/vue.js
@@ -26,6 +26,7 @@ module.exports = {
         'renderError'
       ]
     }],
-    'vue/require-default-prop': ['off']
+    'vue/require-default-prop': ['off'],
+    'vue/component-definition-name-casing': ['error', 'kebab-case']
   }
 }

--- a/vue.js
+++ b/vue.js
@@ -1,0 +1,31 @@
+module.exports = {
+  extends: [
+    'plugin:vue/recommended'
+  ],
+  rules: {
+    'vue/order-in-components': ['error', {
+      order: [
+        'el',
+        'name',
+        'parent',
+        'functional',
+        'template',
+        ['delimiters', 'comments'],
+        ['components', 'directives', 'filters'],
+        'extends',
+        'mixins',
+        'inheritAttrs',
+        'model',
+        ['props', 'propsData'],
+        'data',
+        'computed',
+        'watch',
+        'LIFECYCLE_HOOKS',
+        'methods',
+        'render',
+        'renderError'
+      ]
+    }],
+    'vue/require-default-prop': ['off']
+  }
+}


### PR DESCRIPTION
This PR has several changes:

- We have upgrade the dependencies to work with the last version of each. 
- Configuration has also be splitted in two parts, `nosolosoftware` and `nosolosoftware/vue`. This enables us to use our styleguide in projects where vue was not present without having to install eslint-config-vue. 
- Additionally, a new rule vuejs has been added to work with our standard.
- ecmaVersion has been upgraded to remove babel-eslint of our projects.
- homepage url from package.json has been updated.
- Minor changes in .editorconfig, fixed some typos and updated to use our internal last version.

A new major version has to be released